### PR TITLE
Handle browser zoom correctly.

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -219,8 +219,8 @@ function saveVoxelTexture() {
 function resize() 
 {
 
-  var displayWidth  = window.innerWidth;
-  var displayHeight = window.innerHeight;
+  var displayWidth  = Math.floor(window.innerWidth * window.devicePixelRatio);
+  var displayHeight = Math.floor(window.innerHeight * window.devicePixelRatio);
 
   // Check if the canvas is not the same size.
   if (canvas.width  != displayWidth ||


### PR DESCRIPTION
The devicePixelRatio changes along with the browser's zoom factor, so
use this when recaulculating the canvas's new size to avoid having it
become huge if the browser is zoomed out.

Fixes Issue #1.